### PR TITLE
Bump for GHC 8.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
     - env: CABALVER=2.4 GHCVER=8.6.1
       compiler: ": #GHC 8.6.1"
       addons: {apt: {packages: [cabal-install-2.4,ghc-8.6.1], sources: [hvr-ghc]}}
+    - env: CABALVER=3.0 GHCVER=8.8.1
+      compiler: ": #GHC 8.8.1"
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.8.1], sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       compiler: ": #GHC HEAD"
       addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}

--- a/microlens-th/microlens-th.cabal
+++ b/microlens-th/microlens-th.cabal
@@ -35,8 +35,8 @@ library
                      , containers >=0.4.0 && <0.7
                      , transformers
                      -- lens has >=2.4, but GHC 7.4 shipped with 2.7
-                     , template-haskell >=2.7 && <2.15
-                     , th-abstraction >=0.2.1 && <0.3
+                     , template-haskell >=2.7 && <2.16
+                     , th-abstraction >=0.2.1 && <0.3.1
 
   if flag(inlining)
     cpp-options: -DINLINING

--- a/microlens/src/Lens/Micro.hs
+++ b/microlens/src/Lens/Micro.hs
@@ -1412,9 +1412,11 @@ instance (Monad m) => Monad (StateT s m) where
     m >>= k  = StateT $ \ s -> do
         ~(a, s') <- runStateT m s
         runStateT (k a) s'
+#if !MIN_VERSION_base(4,13,0)
     {-# INLINE (>>=) #-}
     fail str = StateT $ \ _ -> fail str
     {-# INLINE fail #-}
+#endif
 
 #if MIN_VERSION_base(4,9,0)
 instance (Fail.MonadFail m) => Fail.MonadFail (StateT s m) where


### PR DESCRIPTION
This bumps package bounds and fixes `microlens` for GHC 8.8.1